### PR TITLE
 Non/Covalent distanceAB parameter

### DIFF
--- a/cid92930.enzdes.cst
+++ b/cid92930.enzdes.cst
@@ -8,7 +8,7 @@ CST::BEGIN
   TEMPLATE::    ATOM_MAP:   1     residue3: LG1
   TEMPLATE::    ATOM_MAP:   2     atom_name: OE2 CD CG
   TEMPLATE::    ATOM_MAP:   2     residue1: E 
-  CONSTRAINT::  distanceAB: 2.0   0.25   500.0   1 
+  CONSTRAINT::  distanceAB: 2.0   0.25   500.0   1  #this is a covalent intermediate
   CONSTRAINT::  angle_A:    180.0 5.0   500.0   360 
   CONSTRAINT::  angle_B:    120.0 5.0   500.0   360
   CONSTRAINT::  torsion_B:  180.0 10.0  500.0   360
@@ -21,7 +21,7 @@ CST::BEGIN
   TEMPLATE::    ATOM_MAP:   1     residue3:   LG1
   TEMPLATE::    ATOM_MAP:   2     atom_name:  OE2 CD CG
   TEMPLATE::    ATOM_MAP:   2     residue1:   E
-  CONSTRAINT::  distanceAB: 2.75  0.25        500.0   1   
+  CONSTRAINT::  distanceAB: 2.75  0.25        500.0   0 # zero means not covalent   
   CONSTRAINT::  angle_B:    120.0 5.0         500.0   360  
   CONSTRAINT::  torsion_B:  180.0 10.0        500.0   360
 CST::END
@@ -33,5 +33,5 @@ CST::BEGIN
   TEMPLATE::    ATOM_MAP:   1   residue1: E
   TEMPLATE::    ATOM_MAP:   2   atom_type: OH
   TEMPLATE::    ATOM_MAP:   2   residue1: Y
-  CONSTRAINT:: distanceAB: 3.0 0.5 500.0 1
+  CONSTRAINT:: distanceAB: 3.0 0.5 500.0 0
 CST::END


### PR DESCRIPTION
Hey Alex,
I think we might have talked about this before, just wanted to point it out.

Change 2 of the 3 distanceAB parameters from covalent(1) to noncovalent(0), see ref @ https://www.rosettacommons.org/manuals/archive/rosetta3.4_user_guide/d5/dd4/match_cstfile_format.html
